### PR TITLE
「AndoridViewModel」から「ViewModel」への修正。

### DIFF
--- a/app/src/main/java/com/example/pianocoverbook/MainActivity.kt
+++ b/app/src/main/java/com/example/pianocoverbook/MainActivity.kt
@@ -26,9 +26,7 @@ import androidx.navigation.compose.composable
 class MainActivity : ComponentActivity() {
     private val repository: MusicInfoRepository = MusicInfoRepository()
     private val musicInfoDao: MusicInfoDao
-        get() {
-            TODO()
-        }
+        get() { TODO() }
     private val viewModel: MusicInfoViewModel by viewModels {
         MusicInfoViewModelFactory(repository, musicInfoDao)
     }

--- a/app/src/main/java/com/example/pianocoverbook/MainActivity.kt
+++ b/app/src/main/java/com/example/pianocoverbook/MainActivity.kt
@@ -24,7 +24,14 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.compose.composable
 
 class MainActivity : ComponentActivity() {
-    private val viewModel: MusicInfoViewModel by viewModels()
+    private val repository: MusicInfoRepository = MusicInfoRepository()
+    private val musicInfoDao: MusicInfoDao
+        get() {
+            TODO()
+        }
+    private val viewModel: MusicInfoViewModel by viewModels {
+        MusicInfoViewModelFactory(repository, musicInfoDao)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/pianocoverbook/MainActivity.kt
+++ b/app/src/main/java/com/example/pianocoverbook/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.example.pianocoverbook
 
-import android.app.Application
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -18,7 +17,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.fragment.app.viewModels
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -26,16 +24,18 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.compose.composable
 
 class MainActivity : ComponentActivity() {
+    private val viewModel: MusicInfoViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            MyApp()
+            MyApp(viewModel = viewModel)
         }
     }
 }
 
 @Composable
-private fun MyApp() {
+private fun MyApp(viewModel: MusicInfoViewModel) {
     val navController = rememberNavController()
     Scaffold(
         bottomBar = { BottomNavigationBar(navController) }
@@ -46,7 +46,7 @@ private fun MyApp() {
             Modifier.padding(innerPadding)
         ) {
             composable("confirm") { ConfirmScreen() }
-            composable("record") { RecordScreen(viewModel = MusicInfoViewModel(application = Application())) }
+            composable("record") { RecordScreen(viewModel = viewModel) }
             composable("setting") { SettingScreen() }
         }
     }

--- a/app/src/main/java/com/example/pianocoverbook/MusicInfoViewModel.kt
+++ b/app/src/main/java/com/example/pianocoverbook/MusicInfoViewModel.kt
@@ -1,19 +1,15 @@
 package com.example.pianocoverbook
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.room.Room
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-class MusicInfoViewModel(application: Application) : AndroidViewModel(application) {
-    private val repository = MusicInfoRepository()
-    private val musicInfoDao: MusicInfoDao = Room.databaseBuilder(
-        application,
-        MusicInfoDatabase::class.java, "music_info_database"
-    ).build().musicInfoDao()
+class MusicInfoViewModel(
+    private val repository: MusicInfoRepository,
+    private val musicInfoDao: MusicInfoDao
+) : ViewModel() {
 
     private val _musicInfo = MutableStateFlow<List<MusicInfo>>(emptyList())
     val musicInfo: StateFlow<List<MusicInfo>> = _musicInfo
@@ -26,8 +22,6 @@ class MusicInfoViewModel(application: Application) : AndroidViewModel(applicatio
 
     fun saveValues(textOfMusic: String, textOfArtist: String, textOfMemo: String) {
         viewModelScope.launch {
-            // ここでデータベースの処理などを行う
-            // 例: Roomを使用してデータの保存
             repository.saveMusicInfo(textOfMusic, textOfArtist, textOfMemo)
         }
     }

--- a/app/src/main/java/com/example/pianocoverbook/MusicInfoViewModelFactory.kt
+++ b/app/src/main/java/com/example/pianocoverbook/MusicInfoViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.example.pianocoverbook
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class MusicInfoViewModelFactory(
+    private val repository: MusicInfoRepository,
+    private val musicInfoDao: MusicInfoDao
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(MusicInfoViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return MusicInfoViewModel(repository, musicInfoDao) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/example/pianocoverbook/RecordFragment.kt
+++ b/app/src/main/java/com/example/pianocoverbook/RecordFragment.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -115,11 +117,14 @@ fun RecordScreen(viewModel: MusicInfoViewModel) {
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
-private fun RecordScreenPreview() {
+private fun RecordScreenPreview(
+    @PreviewParameter(PreviewParameterProvider::class)
+    viewModel: MusicInfoViewModel
+) {
     PianoCoverBookTheme {
-        RecordScreen()
+        RecordScreen(viewModel = viewModel)
     }
 }
 

--- a/app/src/main/java/com/example/pianocoverbook/RecordFragment.kt
+++ b/app/src/main/java/com/example/pianocoverbook/RecordFragment.kt
@@ -1,6 +1,5 @@
 package com.example.pianocoverbook
 
-import android.app.Application
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -120,7 +119,7 @@ fun RecordScreen(viewModel: MusicInfoViewModel) {
 @Composable
 private fun RecordScreenPreview() {
     PianoCoverBookTheme {
-        RecordScreen(viewModel = MusicInfoViewModel(application = Application()))
+        RecordScreen()
     }
 }
 


### PR DESCRIPTION
AndoridViewModelからViewModelへ修正しました。

ーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーー

```
private val musicInfoDao: MusicInfoDao
        get() { TODO() }
```

の箇所でビルドエラーが発生したので、
それを回避するためにGPTに聞いたら以下のコードが生成されました。

```
private val musicInfoDao: MusicInfoDao
    get() {
        return MusicInfoDatabase.getInstance(application).musicInfoDao() // データベースからDaoを取得
    }
```

getInstanceの箇所でエラーになって
恐らくMusicInfoDatabaseが抽象クラスだからインスタンス化ができないのだろうと思うのですが
この場合どう対処すべきでしょうか？

この後もGPTに抽象クラスの場合どのように対処すべきか？と聞いて
試行錯誤してみたのですが、おかしな感じになりました。